### PR TITLE
Added Compatibility with Fishpig Splash Pages

### DIFF
--- a/app/design/frontend/base/default/layout/strategery-infinitescroll.xml
+++ b/app/design/frontend/base/default/layout/strategery-infinitescroll.xml
@@ -40,6 +40,14 @@
         <update handle="infinitescroll"/>
     </catalogsearch_advanced_result>
 
+    <attributesplash_page_view>
+        <update handle="infinitescroll"/>
+    </attributesplash_page_view>
+
+    <splash_page_view>
+        <update handle="infinitescroll"/>
+    </splash_page_view>
+
 
     <infinitescroll>
         <reference name="head">


### PR DESCRIPTION
This ensures that the infinite scroll is also applied to the Fishpig splash pages (which are also category-like product list pages):

- http://fishpig.co.uk/magento/extensions/attribute-splash-pages/
- http://fishpig.co.uk/magento/extensions/attribute-splash-pro/