### PR TITLE
removed custom feed update methods

### DIFF
--- a/app/code/community/Strategery/Infinitescroll/Model/Admin/Feed.php
+++ b/app/code/community/Strategery/Infinitescroll/Model/Admin/Feed.php
@@ -32,16 +32,4 @@ class Strategery_Infinitescroll_Model_Admin_Feed extends Mage_AdminNotification_
         return $this->_feedUrl;
     }
 
-    public function getLastUpdate()
-    {
-        return Mage::app()->loadCache('infinitescroll_notifications_lastcheck');
-    }
-
-    public function setLastUpdate()
-    {
-        $now = Varien_Date::now();
-        Mage::app()->saveCache($now, 'infinitescroll_notifications_lastcheck');
-        return $this;
-    }
-
 }


### PR DESCRIPTION
Feed update time is handled by `Mage_AdminNotification_Model_Feed` already. There is no need in overriding these methods IMHO. This fixes #194.